### PR TITLE
fix: window position jump on devices with higher pixel ratio

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -565,7 +565,7 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "draw-on-screen"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -565,7 +565,7 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "draw-on-screen"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "draw-on-screen"
-version = "0.7.1"
+version = "0.7.2"
 description = "A Tauri App"
 authors = ["aryan02420"]
 license = ""

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "draw-on-screen"
-version = "0.7.2"
+version = "0.7.3"
 description = "A Tauri App"
 authors = ["aryan02420"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "draw-on-screen",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "tauri": {
     "allowlist": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "draw-on-screen",
-    "version": "0.7.2"
+    "version": "0.7.3"
   },
   "tauri": {
     "allowlist": {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -4,30 +4,35 @@ import type { Position } from './state'
 import { closeSettings } from './settings'
 import { getWindowPosition, osSpecificFullWindow, setWindowPosition, osSpecificMiniWindow } from '../utils/appwindow'
 
+const devicePixelRatio = window?.devicePixelRatio || 1
+
 export function toggleMode() {
-  appMode.update((m) => {
-    if (m === AppMode.quiet) {
-      setPosition(null)
-      osSpecificFullWindow()
+  appMode.update((currentMode) => {
+    if (currentMode === AppMode.quiet) {
+      getWindowPosition().then(async (windowPosition) => {
+        await osSpecificFullWindow()
+        const fullScreenOffset = await getWindowPosition()
+        setPosition([windowPosition[0] - fullScreenOffset[0], windowPosition[1] - fullScreenOffset[1]])
+      })
       return AppMode.draw
     }
     closeSettings()
-    osSpecificMiniWindow().then(() => {
-      setWindowPosition(get(position))
+    getWindowPosition().then(async (fullScreenOffset) => {
+      await osSpecificMiniWindow()
+      const pos = getPosition()
+      setWindowPosition([pos[0] + fullScreenOffset[0], pos[1] + fullScreenOffset[1]])
     })
     return AppMode.quiet
   })
 }
 
-export function setPosition(p: Position | null) {
-  if (p !== null) {
-    position.set(p)
-    return
-  }
+export function getPosition() {
+  const pos = get(position)
+  return [pos[0] * devicePixelRatio, pos[1] * devicePixelRatio] as Position
+}
 
-  getWindowPosition().then((pos) => {
-    position.set(pos)
-  })
+export function setPosition(p: Position) {
+  position.set([p[0] / devicePixelRatio, p[1] / devicePixelRatio])
 }
 
 export function offsetPosition(p: Position) {

--- a/src/utils/appwindow.ts
+++ b/src/utils/appwindow.ts
@@ -1,10 +1,9 @@
 import { exit } from '@tauri-apps/api/process'
-import { appWindow, PhysicalPosition } from '@tauri-apps/api/window'
+import { appWindow, LogicalPosition, PhysicalPosition } from '@tauri-apps/api/window'
 import { type as osType } from '@tauri-apps/api/os'
 import { open } from '@tauri-apps/api/shell'
 
 import type { Position } from '../store/state'
-
 
 export const closeWindow = async () => {
   try {
@@ -67,7 +66,7 @@ export const getWindowPosition = async (): Promise<Position> => {
 
 export const setWindowPosition = async ([x, y]: Position) => {
   try {
-    const pos = new PhysicalPosition(x, y)
+    const pos = new LogicalPosition(x, y)
     await appWindow.setPosition(pos)
   } catch {}
 }

--- a/src/utils/appwindow.ts
+++ b/src/utils/appwindow.ts
@@ -1,5 +1,5 @@
 import { exit } from '@tauri-apps/api/process'
-import { appWindow, LogicalPosition, PhysicalPosition } from '@tauri-apps/api/window'
+import { appWindow, PhysicalPosition } from '@tauri-apps/api/window'
 import { type as osType } from '@tauri-apps/api/os'
 import { open } from '@tauri-apps/api/shell'
 
@@ -66,7 +66,7 @@ export const getWindowPosition = async (): Promise<Position> => {
 
 export const setWindowPosition = async ([x, y]: Position) => {
   try {
-    const pos = new LogicalPosition(x, y)
+    const pos = new PhysicalPosition(x, y)
     await appWindow.setPosition(pos)
   } catch {}
 }


### PR DESCRIPTION
was breaking on apple retina display. main toolbar was jumping to new position when entering edit mode